### PR TITLE
Fix README and CHANGELOG before publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 v0.2:
 - Fixed menu item linking to wiring screen
-- Moved ledBlinking from [Sensor] to [App] section in configuration file
+- Moved ledBlinking from Sensor to App section in configuration file
 - Added current/voltage recording to the CSV file
 
 v0.1:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ INA Meter is an application for Flipper Zero that allows you to read I2C-connect
 - Once the settings are complete, press the BACK button to return to the Current Gauge Screen.
 - If the sensor is connected properly, the Current Gauge Screen will display the bus voltage and the current flowing through the shunt resistor.
 
-The application allows measured values to be saved to a CSV file on the SD card. A CSV file is automatically created when recording starts and is stored in the `/apps_data/ina_meter/logs` folder. Its name is derived from the date and time the recording begins.
+The application allows measured values to be saved to a CSV file on the SD card. A CSV file is automatically created when recording starts and is stored in the */apps_data/ina_meter/logs* folder. Its name is derived from the date and time the recording begins.
 
 ## Precision and Sampling Presets
 


### PR DESCRIPTION
Minor fixes in CHANGELOG and README that were blocking publication in the Flipper app catalog.